### PR TITLE
add: add linters and formaters to the package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -21,14 +21,24 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest coverage
+        python -m pip install ruff pytest coverage bandit
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Lint with ruff
+      uses: chartboost/ruff-action@v1
+      with:
+        src: './local_workspace_sync'
+    - name: Format with ruff
+      uses: chartboost/ruff-action@v1
+      with:
+        args: 'format --check --diff'
+    - name: Security Lint with Bandit
+      uses: mdegis/bandit-action@v1.0
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        path: "./local_workspace_sync"
+        level: high
+        confidence: high
+        exit_zero: true
     - name: Test with pytest
       run: |
         coverage run -m pytest tests

--- a/local_workspace_sync/main.py
+++ b/local_workspace_sync/main.py
@@ -1,3 +1,2 @@
-
 def add_numbers(var1, var2):
     return var1 + var2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,19 @@ fail_under = 80
 
 [tool.coverage.html]
 directory = ".coverage_html_report"
+
+[tool.ruff.lint]
+select = [
+    'A',
+    'E',
+    'F',
+    'Q',
+    'W',
+    'S'
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 88

--- a/tests/test_local_workspace_sync_executor.py
+++ b/tests/test_local_workspace_sync_executor.py
@@ -2,7 +2,6 @@ from local_workspace_sync import main
 
 
 class TestLocalWorkspaceSyncExecutor:
-
     def test_add_numbers(self):
         value = main.add_numbers(10, 20)
         assert value == 30


### PR DESCRIPTION
- migrated from flake8 to ruff
- added github actions for ruff linting and formating
- added github actions for bandit security linting